### PR TITLE
Prefer (CONST_)CSTR_STRING over CHARS_STRING

### DIFF
--- a/src/gap_cpp_headers/gap_cpp_mapping.hpp
+++ b/src/gap_cpp_headers/gap_cpp_mapping.hpp
@@ -51,7 +51,7 @@ struct GAP_getter<char*>
     {
         if(!isa(recval))
             throw GAPException("Invalid attempt to read string");
-        return (char*)CHARS_STRING(recval);
+        return CSTR_STRING(recval);
     }
 };
 
@@ -65,7 +65,7 @@ struct GAP_getter<std::string>
     {
         if(!isa(recval))
             throw GAPException("Invalid attempt to read string");
-        return std::string((char*)CHARS_STRING(recval));
+        return std::string(CONST_CSTR_STRING(recval));
     }
 };
 


### PR DESCRIPTION
... at least where it avoids casts
