### PR TITLE
CI: test against more GAP kernel versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,9 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.14
+          - stable-4.13
+          - stable-4.12
         ABI: ['']
         include:
           - gap-branch: master


### PR DESCRIPTION
... since this package is broken against GAP master and 4.14 (see #22) it is useful to see if it works in older GAP versions.